### PR TITLE
Support Wayland in desktop manager

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ AC_ARG_ENABLE(debug,
     [enable_debug="${enableval}"],
     [enable_debug=no])
 
-if test "$enable_debug" = "yes"; then
+if test x"$enable_debug" = "xyes"; then
     # turn on debug and disable optimization
     CPPFLAGS="$CPPFLAGS -DG_ENABLE_DEBUG -O0 -g"
     case "$CC" in
@@ -86,33 +86,40 @@ AC_ARG_ENABLE(wayland,
     [enable_wayland="${enableval}"],
     [enable_wayland=no])
 
+AC_ARG_ENABLE(x11,
+    [AC_HELP_STRING([--enable-x11],
+        [Enable X11 support])],
+    [enable_x11="${enableval}"],
+    [enable_x11=yes])
+
+if test x"$enable_wayland" = "xno" -a x"&$enable_x11" = "xno"; then
+    AC_MSG_ERROR([At least one of X11 and Wayland needs to be enabled])
+fi
+
 # Checks for libraries.
+fm_modules="gthread-2.0 gio-unix-2.0 >= 2.18.0 glib-2.0 pango >= 1.20.0 libfm >= 1.0"
 
-PKG_CHECK_MODULES(XLIB, "x11")
-AC_SUBST(XLIB_CFLAGS)
-AC_SUBST(XLIB_LIBS)
-
-gio_modules="gthread-2.0 gio-unix-2.0 >= 2.18.0"
-PKG_CHECK_MODULES(GIO, [$gio_modules])
-AC_SUBST(GIO_CFLAGS)
-AC_SUBST(GIO_LIBS)
-
-fm_modules="$gio_modules glib-2.0 pango >= 1.20.0 libfm >= 1.0"
 case "$ac_with_gtk" in
     3|3.*)
         fm_modules="$fm_modules gtk+-3.0 libfm-gtk3 >= 1.0.1"
-        if test "x$enable_wayland" = "xyes"; then
+        if test x"$enable_wayland" = "xyes"; then
             fm_modules="$fm_modules gtk-layer-shell-0 >= 0.5.2"
             AC_DEFINE(HAVE_WAYLAND, 1, [Have Wayland support])
         fi
         ;;
     *)
         fm_modules="$fm_modules gtk+-2.0 libfm-gtk >= 1.0.1"
-        if test "x$enable_wayland" = "xyes"; then
+        if test x"$enable_wayland" = "xyes"; then
             AC_MSG_ERROR([Wayland only works with GTK3])
         fi
         ;;
 esac
+
+if test x"$enable_x11" = "xyes"; then
+    fm_modules="$fm_modules x11"
+    AC_DEFINE(HAVE_X11, 1, [Have X11 support])
+fi
+
 PKG_CHECK_MODULES(FM, [$fm_modules])
 AC_SUBST(FM_CFLAGS)
 AC_SUBST(FM_LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,12 @@ AC_ARG_WITH(gtk,
     [ac_with_gtk="${withval}"],
     [ac_with_gtk=2])
 
+AC_ARG_ENABLE(wayland,
+    [AC_HELP_STRING([--enable-wayland],
+        [Enable Wayland support])],
+    [enable_wayland="${enableval}"],
+    [enable_wayland=no])
+
 # Checks for libraries.
 
 PKG_CHECK_MODULES(XLIB, "x11")
@@ -95,9 +101,16 @@ fm_modules="$gio_modules glib-2.0 pango >= 1.20.0 libfm >= 1.0"
 case "$ac_with_gtk" in
     3|3.*)
         fm_modules="$fm_modules gtk+-3.0 libfm-gtk3 >= 1.0.1"
+        if test "x$enable_wayland" = "xyes"; then
+            fm_modules="$fm_modules gtk-layer-shell-0 >= 0.5.2"
+            AC_DEFINE(HAVE_WAYLAND, 1, [Have Wayland support])
+        fi
         ;;
     *)
         fm_modules="$fm_modules gtk+-2.0 libfm-gtk >= 1.0.1"
+        if test "x$enable_wayland" = "xyes"; then
+            AC_MSG_ERROR([Wayland only works with GTK3])
+        fi
         ;;
 esac
 PKG_CHECK_MODULES(FM, [$fm_modules])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,7 +38,6 @@ EXTRA_DIST= \
 include_HEADERS = pcmanfm-modules.h
 
 pcmanfm_CFLAGS = \
-	$(XLIB_CFLAGS) \
 	$(FM_CFLAGS) \
 	$(G_CAST_CHECKS) \
 	-Wall \
@@ -46,7 +45,6 @@ pcmanfm_CFLAGS = \
 	$(NULL)
 
 pcmanfm_LDADD = \
-	$(XLIB_LIBS) \
 	$(FM_LIBS) \
 	$(NULL)
 

--- a/src/desktop.h
+++ b/src/desktop.h
@@ -96,6 +96,9 @@ struct _FmDesktop
     guint search_timeout_id;
     /* desktop settings for this monitor */
     FmDesktopConfig conf;
+#ifdef HAVE_WAYLAND
+    GtkWindow *wallpaper_window;
+#endif
 };
 
 struct _FmDesktopClass

--- a/src/pcmanfm.c
+++ b/src/pcmanfm.c
@@ -575,7 +575,8 @@ gboolean pcmanfm_open_folder(GAppLaunchContext* ctx, GList* folder_infos, gpoint
         FmFileInfo* fi = (FmFileInfo*)l->data;
         fm_main_win_open_in_last_active(fm_file_info_get_path(fi));
     }
-    if(user_data && FM_IS_DESKTOP(user_data))
+    if(user_data && FM_IS_DESKTOP(user_data) &&
+            GDK_IS_X11_WINDOW(gtk_widget_get_window(GTK_WIDGET(user_data))))
         move_window_to_desktop(fm_main_win_get_last_active(), user_data);
     return TRUE;
 }

--- a/src/pcmanfm.c
+++ b/src/pcmanfm.c
@@ -37,6 +37,10 @@
 #include <signal.h>
 #include <unistd.h> /* for getcwd */
 
+#ifdef HAVE_WAYLAND
+#include <gtk-layer-shell/gtk-layer-shell.h>
+#endif
+
 #include <libfm/fm-gtk.h>
 #include "app-config.h"
 #include "main-win.h"
@@ -349,6 +353,19 @@ gboolean pcmanfm_run(gint screen_num)
         {
             if(!desktop_running)
             {
+                GdkDisplay *default_display = gdk_display_get_default();
+#if HAVE_WAYLAND
+                if(!GDK_IS_X11_DISPLAY(default_display) && !gtk_layer_is_supported())
+                {
+                    fm_show_error(NULL, NULL, _("Only X11 and Wayland (with wlr-layer-shell) are supported"));
+#else
+                if(!GDK_IS_X11_DISPLAY(default_display))
+                {
+                    fm_show_error(NULL, NULL, _("Only X11 is supported"));
+#endif
+                    reset_options();
+                    return FALSE;
+                }
                 fm_desktop_manager_init(one_screen ? screen_num : -1);
                 desktop_running = TRUE;
             }


### PR DESCRIPTION
This PR adds optional Wayland support to PCManFM's desktop manager through the [GTK Layer Shell](https://github.com/wmww/gtk-layer-shell) library.

![Screenshot of PCManFM's desktop manager on Wayfire](https://user-images.githubusercontent.com/46277131/107074771-7a30ee00-67e9-11eb-9b9a-8ecc0fafb6e0.png)

To do:

- [x] Make X11 support optional as well
- [x] When starting the desktop manager, display an appropriate error message if an unsupported display protocol is used
- [x] Do not show desktop icons underneath e.g. panels

This PR depends on lxde/libfm#70 for right-click menus to work properly.

I set the dependency on v0.5.2 of GTK Layer Shell even though it would successfully compile with earlier versions, because that's the version some issue that would make the `search_window` unusable got [fixed](https://github.com/wmww/gtk-layer-shell/pull/103).