### PR TITLE
po/de.po: fix build with gettext-tiny

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -961,8 +961,7 @@ msgstr "Diese Ordneransicht merken"
 #: ../src/main-win-ui.c:279
 msgid ""
 "Check to remember view and sort as folder setting rather than global one"
-msgstr
-"Ansicht und Sortierung für dieses Verzeichnis anstelle der globalen "
+msgstr "Ansicht und Sortierung für dieses Verzeichnis anstelle der globalen "
 "Einstellung merken"
 
 #: ../src/main-win-ui.c:281


### PR DESCRIPTION
Build of `de.gmo` is broken with gettext-tiny since version 1.3.2 and commit 80e0f662861e6d0ad8888f61c19c0695978779bf:

```
file=`echo de | sed 's,.*/,,'`.gmo \
  && rm -f $file && /home/buildroot/autobuild/instance-2/output-1/host/bin/msgfmt -o $file de.po
Makefile:102: recipe for target 'de.gmo' failed
```

Fixes:
 - http://autobuild.buildroot.org/results/69f4e5fa44208429b143011640971a61d709d5b1

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>