### PR TITLE
Update ja.po - fix wrong Japanese Translation 

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -282,7 +282,7 @@ msgstr "ファイルのサムネイルを表示する(_S)"
 
 #: ../data/ui/pref.glade.h:32
 msgid "_Only show thumbnails for local files"
-msgstr "ローカルのファイルにはサムネイルだけを表示する(_O)"
+msgstr "ローカルのファイルにのみサムネイルを表示する(_O)"
 
 #: ../data/ui/pref.glade.h:33
 msgid "Do _not generate thumbnails for files exceeding this size:"


### PR DESCRIPTION
correct Japanese wrong translation. 
```
ローカルのファイルにはサムネイルだけを表示する→ローカルのファイルにのみサムネイルを表示する
```