### PR TITLE
Add date-time-format option

### DIFF
--- a/data/ui/pref.glade
+++ b/data/ui/pref.glade
@@ -975,6 +975,49 @@
                                     <property name="position">3</property>
                                   </packing>
                                 </child>
+                                <child>
+                                  <object class="GtkHBox" id="hbox_date_time_format">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label_date_time_format">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">_Date-time format (strftime; default '%x %R'):</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="mnemonic_widget">date_time_format</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="date_time_format">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="activates_default">True</property>
+                                        <property name="primary_icon_activatable">False</property>
+                                        <property name="secondary_icon_activatable">False</property>
+                                        <property name="primary_icon_sensitive">True</property>
+                                        <property name="secondary_icon_sensitive">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">3</property>
+                                    <property name="position">4</property>
+                                  </packing>
+                                </child>
                               </object>
                             </child>
                           </object>

--- a/src/pref.c
+++ b/src/pref.c
@@ -751,6 +751,7 @@ void fm_edit_preference( GtkWindow* parent, int page )
         INIT_BOOL_SHOW(builder, FmConfig, show_full_names, NULL);
         INIT_BOOL_SHOW(builder, FmConfig, shadow_hidden, NULL);
 #endif
+        INIT_ENTRY(builder, FmConfig, date_time_format, NULL);
 
         /* 'Layout' tab */
         INIT_BOOL(builder, FmAppConfig, hide_close_btn, NULL);


### PR DESCRIPTION
Currently, the format for date-time (as used in PCManFM’s ‘Modified’ column) is based on locale. The only way to change it (e.g. to ISO 8601) is to switch (or modify) the locale. Users might prefer to configure the date-time format within PCManFM Preferences.

Here is a simple manual setting, using strftime, similar to LXDE’s Digital Clock applet.