### PR TITLE
Show desktop preferences entry only in LXDE

### DIFF
--- a/data/pcmanfm-desktop-pref.desktop.in
+++ b/data/pcmanfm-desktop-pref.desktop.in
@@ -7,4 +7,4 @@ Categories=Settings;GTK;DesktopSettings;X-LXDE-Settings;
 Exec=pcmanfm --desktop-pref
 StartupNotify=true
 Terminal=false
-NotShowIn=GNOME;XFCE;KDE;MATE;
+OnlyShowIn=LXDE;


### PR DESCRIPTION
Most desktop environments have their own desktop icons nowadays, and PCManFM is used only in LXDE by default.