### PR TITLE
Add fixed-width tab label option in GTK3

### DIFF
--- a/data/ui/pref.glade
+++ b/data/ui/pref.glade
@@ -1112,6 +1112,23 @@
                                   </packing>
                                 </child>
                                 <child>
+                                  <object class="GtkCheckButton" id="fixed_width_tab">
+                                    <property name="label" translatable="yes">Use _fixed-width tab label</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                                    <property name="use_action_appearance">False</property>
+                                    <property name="use_underline">True</property>
+                                    <property name="xalign">0</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                                <child>
                                   <object class="GtkHBox" id="hbox8">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
@@ -1165,7 +1182,7 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
-                                    <property name="position">2</property>
+                                    <property name="position">3</property>
                                   </packing>
                                 </child>
                               </object>

--- a/src/app-config.c
+++ b/src/app-config.c
@@ -678,6 +678,9 @@ void fm_app_config_load_from_key_file(FmAppConfig* cfg, GKeyFile* kf)
 
     /* ui */
     fm_key_file_get_bool(kf, "ui", "always_show_tabs", &cfg->always_show_tabs);
+#if GTK_CHECK_VERSION(3, 0, 0)
+    fm_key_file_get_bool(kf, "ui", "fixed_width_tab", &cfg->fixed_width_tab);
+#endif
     fm_key_file_get_int(kf, "ui", "hide_close_btn", &cfg->hide_close_btn);
     fm_key_file_get_int(kf, "ui", "max_tab_chars", &cfg->max_tab_chars);
 
@@ -1119,6 +1122,9 @@ void fm_app_config_save_profile(FmAppConfig* cfg, const char* name)
 
         g_string_append(buf, "\n[ui]\n");
         g_string_append_printf(buf, "always_show_tabs=%d\n", cfg->always_show_tabs);
+#if GTK_CHECK_VERSION(3, 0, 0)
+        g_string_append_printf(buf, "fixed_width_tab=%d\n", cfg->fixed_width_tab);
+#endif
         g_string_append_printf(buf, "max_tab_chars=%d\n", cfg->max_tab_chars);
         /* g_string_append_printf(buf, "hide_close_btn=%d\n", cfg->hide_close_btn); */
         g_string_append_printf(buf, "win_width=%d\n", cfg->win_width);

--- a/src/app-config.h
+++ b/src/app-config.h
@@ -115,6 +115,9 @@ struct _FmAppConfig
 
     /* ui */
     gboolean always_show_tabs;
+#if GTK_CHECK_VERSION(3, 0, 0)
+    gboolean fixed_width_tab;
+#endif
     gboolean hide_close_btn;
     int max_tab_chars;
     int win_width;

--- a/src/pref.c
+++ b/src/pref.c
@@ -789,6 +789,9 @@ void fm_edit_preference( GtkWindow* parent, int page )
         /* 'Layout' tab */
         INIT_BOOL(builder, FmAppConfig, hide_close_btn, NULL);
         INIT_BOOL(builder, FmAppConfig, always_show_tabs, NULL);
+#if GTK_CHECK_VERSION(3, 0, 0)
+        INIT_BOOL_SHOW(builder, FmAppConfig, fixed_width_tab, NULL);
+#endif
         INIT_SPIN(builder, FmAppConfig, max_tab_chars, NULL);
 
 #if FM_CHECK_VERSION(1, 0, 2)

--- a/src/tab-page.c
+++ b/src/tab-page.c
@@ -846,6 +846,37 @@ static void update_files_popup(FmFolderView* fv, GtkWindow* win,
         gtk_action_set_visible(gtk_action_group_get_action(act_grp, "Term"), FALSE);
 }
 
+/* update tab label after changing directory/filter */
+static void update_tab_label(FmTabLabel *tab_label, const char *disp_name)
+{
+#if GTK_CHECK_VERSION(3, 0, 0)
+    /* tab width dynamically follows string length up to max_tab_chars */
+    if (!app_config->fixed_width_tab)
+    {
+        glong len = g_utf8_strlen(disp_name, -1);
+
+        /* Pango sometimes ellipsizes string with length below max_tab_chars due to it using
+           average character width instead of string character count, so here we handle it manually.
+           This still has problem in handling i18n characters (e.g. CJK) where ellipsization
+           results in far lower (around half max_tab_chars) character count. In GTK2 it's even worse;
+           text just cuts off in the middle without ellipses when using PANGO_ELLIPSIZE_NONE.
+           Thus this feature is GTK3 only. */
+        if (len <= app_config->max_tab_chars)
+        {
+            gtk_label_set_width_chars(tab_label->label, len);
+            gtk_label_set_ellipsize(tab_label->label, PANGO_ELLIPSIZE_NONE);
+        }
+        else
+        {
+            gtk_label_set_width_chars(tab_label->label, app_config->max_tab_chars);
+            gtk_label_set_ellipsize(tab_label->label, PANGO_ELLIPSIZE_END);
+        }
+    }
+#endif
+
+    fm_tab_label_set_text(tab_label, disp_name);
+}
+
 static gboolean open_folder_func(GAppLaunchContext* ctx, GList* folder_infos, gpointer user_data, GError** err)
 {
     FmMainWin* win = FM_MAIN_WIN(user_data);
@@ -964,8 +995,14 @@ static void fm_tab_page_init(FmTabPage *page)
 
     /* create tab label */
     tab_label = (FmTabLabel*)fm_tab_label_new("");
+#if GTK_CHECK_VERSION(3, 0, 0)
+    if (app_config->fixed_width_tab)
+    {
+        gtk_label_set_width_chars(tab_label->label, app_config->max_tab_chars);
+        gtk_label_set_ellipsize(tab_label->label, PANGO_ELLIPSIZE_END);
+    }
+#else
     gtk_label_set_max_width_chars(tab_label->label, app_config->max_tab_chars);
-#if ! GTK_CHECK_VERSION(3, 0, 0)
     gtk_label_set_ellipsize(tab_label->label, PANGO_ELLIPSIZE_END);
 #endif
     page->tab_label = tab_label;
@@ -1030,7 +1067,7 @@ static void fm_tab_page_chdir_without_history(FmTabPage* page, FmPath* path)
         disp_name = text;
     }
 #endif
-    fm_tab_label_set_text(page->tab_label, disp_name);
+    update_tab_label(page->tab_label, disp_name);
     g_free(disp_name);
 
 #if FM_CHECK_VERSION(1, 2, 0)
@@ -1449,7 +1486,7 @@ void fm_tab_page_set_filter_pattern(FmTabPage *page, const char *pattern)
         g_free(disp_name);
         disp_name = text;
     }
-    fm_tab_label_set_text(page->tab_label, disp_name);
+    update_tab_label(page->tab_label, disp_name);
     g_free(disp_name);
 }
 #endif


### PR DESCRIPTION
Currently, tab label maximum width option is ignored when building with GTK3, resulting in unlimited tab label width. This commit will add option to either use fixed-width tab label as per maximum width or fit-to-text up to maximum width, similar to GTK2. Tested on Debian Trixie with X11, GTK2 v2.24.33 and GTK3 v3.24.49.

Screenshots (above window has maximum tab label width of 10 characters, below 15):
### GTK2 
<img width="1278" height="505" alt="gtk2 max_char=10,15" src="https://github.com/user-attachments/assets/0aaa8c91-679c-438d-ad9b-18b54b0e5f22" />

### GTK3 with fixed-width disabled
<img width="1278" height="501" alt="gtk3 max_char=10,15 fixed_width=0" src="https://github.com/user-attachments/assets/1f105d15-ad8b-4c33-aa13-e278fddf6eb3" />

### GTK3 with fixed-width enabled
<img width="1277" height="520" alt="gtk3 max_char=10,15 fixed_width=1" src="https://github.com/user-attachments/assets/478d50b1-be97-46f4-a553-f7529adc0dbe" />
